### PR TITLE
Minor bugfix for a pair of missing parentheses in arrows3d

### DIFF
--- a/R/arrows3d.R
+++ b/R/arrows3d.R
@@ -127,7 +127,7 @@ arrows3d <- function( coords, headlength= 0.035, head= "end", scale= NULL, radiu
   ends   <- coords[ seq( 2, n, by= 2 ), , drop=FALSE]
   if( missing( radius ) ) radius <- ( max( coords ) - min( coords ) ) / 50
 
-  lengths <- sqrt(rowSums(ends - starts)^2)
+  lengths <- sqrt(rowSums((ends - starts)^2))
 
   if (is.null(ref.length)){
     ref.length <- max(lengths)


### PR DESCRIPTION
Dropped parentheses results in some incorrect vector lengths of 0. This would lead to correct segments being drawn but no cones in subsequent arrows3d calls. Example of what this fixes:

> open3d()
wgl
  1
> vectors3d(c(4,-1,3),origin=c(2,2,2)) # error thrown, correct segment graphed but no cone
Error in if (angle == 0) return(identityMatrix()) :
  missing value where TRUE/FALSE needed