### PR TITLE
second attempt to get GramSchmidt() to retain column names

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,5 +37,5 @@ Imports:
     car,
     methods
 VignetteBuilder: knitr
-RoxygenNote: 7.2.2
+RoxygenNote: 7.2.3
 Encoding: UTF-8

--- a/R/GramSchmidt.R
+++ b/R/GramSchmidt.R
@@ -68,7 +68,9 @@ GramSchmidt <- function (X, normalize = TRUE, verbose = FALSE,
   }
   if (normalize) {
     norm <- diag(1/len(B))
+    colnames <- colnames(B)
     B <- B %*% norm
+    colnames(B) <- colnames
     if (!omit_zero_columns && any(zeros)) B[, zeros] <- 0
     if (verbose) {
       cat("\nNormalized matrix: Z * inv(L) \n")


### PR DESCRIPTION
Merge JF's change to retain column names in `GramSchmidt()`